### PR TITLE
Minor change in availability source

### DIFF
--- a/airbyte-integrations/connectors/source-waitwhile/source_waitwhile/source.py
+++ b/airbyte-integrations/connectors/source-waitwhile/source_waitwhile/source.py
@@ -7,7 +7,7 @@ from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.http import HttpStream
 from airbyte_cdk.sources.streams.http.auth import TokenAuthenticator
-
+from datetime import datetime
 
 class WaitwhileStreamAvailability(HttpStream, ABC):
     url_base = "https://api.waitwhile.com/v2/"
@@ -399,7 +399,7 @@ class SourceWaitwhile(AbstractSource):
             Visits(authenticator=auth, start_date=start_date),
             LocationsAvailability(
                 authenticator=auth,
-                start_date=start_date,
+                start_date=datetime.today().strftime('%Y-%m-%d'),
                 location_ids=location_ids,
                 n_days_availability_horizon=n_days_availability_horizon
             ),

--- a/airbyte-integrations/connectors/source-waitwhile/source_waitwhile/spec.yaml
+++ b/airbyte-integrations/connectors/source-waitwhile/source_waitwhile/spec.yaml
@@ -23,9 +23,9 @@ connectionSpecification:
       default: "2022-10-12"
       pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
     n_days_availability_horizon:
-      title: N das availability horizon
+      title: N days availability horizon
       type: integer
-      description: N das availability horizon
+      description: N days availability horizon
       examples:
         - 30
-      default: 3
+      default: 30


### PR DESCRIPTION
Changing start time to be from today for the Location Availability endpoint. This is because we need to do a full refresh every day instead of incremental (Because of the deletion of bookings we are not able to track removed ids)