### PR TITLE
lower count

### DIFF
--- a/airbyte-integrations/connectors/source-tripletex-api/source_tripletex_api/source.py
+++ b/airbyte-integrations/connectors/source-tripletex-api/source_tripletex_api/source.py
@@ -2,12 +2,12 @@
 # Copyright (c) 2022 Airbyte, Inc., all rights reserved.
 #
 
-import json
 import base64
-import pendulum
+import json
 from abc import ABC
 from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Tuple
 
+import pendulum
 import requests
 from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.streams import Stream
@@ -85,7 +85,7 @@ class PostingStream(TripletexApiStream, ABC):
         params = {
             "dateFrom": self.start_date,
             "dateTo": pendulum.parse(self.start_date).add(days=7).format("YYYY-MM-DD"),
-            "count": 100000
+            "count": 10000
         }
 
         if next_page_token:


### PR DESCRIPTION
Tried to sync with new balance_sheet-stream in airbyte but got error with the parameter 'count' being bigger than the allowed 10000.

Pushed new docker image, I believe it worked correctly so need to merge this and try to sync in airbyte again and get the balancesheet data into bigquery

<img width="1512" alt="Screenshot 2023-01-06 at 09 45 10" src="https://user-images.githubusercontent.com/55831996/210964948-fff82aa6-f208-4515-aa08-fc2b8e578781.png">
